### PR TITLE
Fix dealing with non-FAT (e.g. ext4, f2fs) formatted sdcards

### DIFF
--- a/src/com/android/providers/media/MediaProvider.java
+++ b/src/com/android/providers/media/MediaProvider.java
@@ -5330,7 +5330,18 @@ public class MediaProvider extends ContentProvider {
             } else if (EXTERNAL_VOLUME.equals(volume)) {
                 if (Environment.isExternalStorageRemovable()) {
                     final StorageVolume actualVolume = mStorageManager.getPrimaryVolume();
-                    final int volumeId = actualVolume.getFatVolumeId();
+                    int volumeId = actualVolume.getFatVolumeId();
+
+                    // In case of a non-FAT filesystem, try to get the UUID
+                    if (volumeId == -1) {
+                        String uuid = actualVolume.getUuid();
+                        uuid = uuid.replace("-", "");
+                        if (uuid.length() > 8) {
+                            uuid = uuid.substring(0, 8);
+                        }
+                        volumeId = (int)Long.parseLong(uuid, 16);
+                        Log.e(TAG, "UUID: " + volumeId);
+                    }
 
                     // Must check for failure!
                     // If the volume is not (yet) mounted, this will create a new


### PR DESCRIPTION
Backported from e664904f896028762ab3126d0107b21dc8a475a4 in cm-11.
